### PR TITLE
Misc small things :)

### DIFF
--- a/lib/text-extractor.rb
+++ b/lib/text-extractor.rb
@@ -1,0 +1,1 @@
+require 'text_extractor'

--- a/lib/text_extractor/file_handler/external_command_handler.rb
+++ b/lib/text_extractor/file_handler/external_command_handler.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'pathname'
+
 module TextExtractor
   class ExternalCommandHandler < FileHandler
     # TODO: Extract this to a proper module
@@ -22,7 +24,7 @@ module TextExtractor
 
     def text(file)
       cmd = @command.dup
-      cmd[cmd.index(FILE_PLACEHOLDER)] = file.path
+      cmd[cmd.index(FILE_PLACEHOLDER)] = Pathname(file).to_s
       shellout(cmd){ |io| io.read }.to_s
     end
 

--- a/lib/text_extractor/resolver.rb
+++ b/lib/text_extractor/resolver.rb
@@ -17,8 +17,6 @@ module TextExtractor
         text.strip!
         text.mb_chars.compose.limit(MAX_FULLTEXT_LENGTH).to_s
       end
-    rescue Exception => e
-      raise e unless e.is_a? StandardError # re-raise Signals / SyntaxErrors etc
     end
 
     private

--- a/spec/lib/file_handler/external_command_handler/doc_handler_spec.rb
+++ b/spec/lib/file_handler/external_command_handler/doc_handler_spec.rb
@@ -14,6 +14,17 @@ describe TextExtractor::DocHandler do
       expect(TextExtractor::Resolver.new(file, 'application/msword').text).to match /lorem ipsum fulltext find me!/
       expect(TextExtractor::Resolver.new(file, 'application/vnd.ms-word').text).to match /lorem ipsum fulltext find me!/
     end
+
+    it 'Should accept a pathname as input' do
+      file = 'spec/fixtures/files/text.doc'
+      expect(subject.text(file)).to match /lorem ipsum fulltext find me!/
+    end
+
+    it 'Should accept a path string as input' do
+      file = Pathname('spec/fixtures/files/text.doc')
+      expect(subject.text(file)).to match /lorem ipsum fulltext find me!/
+    end
+
   else
     warn "#{described_class.name} could not be tested as external program is not available."
   end

--- a/spec/lib/file_handler/external_command_handler/ppt_handler_spec.rb
+++ b/spec/lib/file_handler/external_command_handler/ppt_handler_spec.rb
@@ -14,6 +14,17 @@ describe TextExtractor::PptHandler do
       expect(TextExtractor::Resolver.new(file, 'application/powerpoint').text).to match /Die Java Virtual Machine/
       expect(TextExtractor::Resolver.new(file, 'application/vnd.ms-powerpoint').text).to match /Die Java Virtual Machine/
     end
+
+    it 'Should accept a pathname as input' do
+      file = 'spec/fixtures/files/presentation.ppt'
+      expect(subject.text(file)).to match /Die Java Virtual Machine/
+    end
+
+    it 'Should accept a path string as input' do
+      file = Pathname('spec/fixtures/files/presentation.ppt')
+      expect(subject.text(file)).to match /Die Java Virtual Machine/
+    end
+
   else
     warn "#{described_class.name} could not be tested as external program is not available."
   end

--- a/spec/lib/file_handler/plaintext_handler_spec.rb
+++ b/spec/lib/file_handler/plaintext_handler_spec.rb
@@ -17,4 +17,16 @@ describe TextExtractor::PlaintextHandler do
     expect(subject.text(file)).to match /lorem/
     expect(TextExtractor::Resolver.new(file, 'text/csv').text).to match /lorem/
   end
+
+  it 'Should accept a path string as input' do
+    file = 'spec/fixtures/files/text.txt'
+    expect(subject.text(file)).to match /lorem/
+    expect(TextExtractor::Resolver.new(file, 'text/plain').text).to match /lorem ipsum/
+  end
+
+  it 'Should accept a pathname as input' do
+    file = Pathname('spec/fixtures/files/text.txt')
+    expect(subject.text(file)).to match /lorem/
+    expect(TextExtractor::Resolver.new(file, 'text/plain').text).to match /lorem ipsum/
+  end
 end

--- a/spec/lib/file_handler/zipped_xml_handler/opendocument_handler_spec.rb
+++ b/spec/lib/file_handler/zipped_xml_handler/opendocument_handler_spec.rb
@@ -6,6 +6,16 @@ describe TextExtractor::OpendocumentHandler do
 
   subject { described_class.new }
   
+  it 'Should accept a path string as input' do
+    file = 'spec/fixtures/files/text.odt'
+    expect(subject.text(file)).to match /lorem ipsum/
+  end
+
+  it 'Should accept a pathname as input' do
+    file = Pathname('spec/fixtures/files/text.odt')
+    expect(subject.text(file)).to match /lorem ipsum/
+  end
+
   it 'Should extract text from .odt files' do
     file = File.new('spec/fixtures/files/text.odt', 'r')
 


### PR DESCRIPTION
This PR contains a couple of minor things I'd like to put up for discussion:

- I'd like to remove the exception handling in `resolver.rb`. It should be up to the calling code to decide what to do with any errors.
- Normally, in a Rails app, you do not have to require any gems that are in the Gemfile. To make this work for this gem as well I added `lib/text-extractor.rb`
- All handlers except the external file handlers worked fine with strings or Pathname objects as file input. I amended the external file handler base class to make this work there as well.

What do you think?