### PR TITLE
Allow post init configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,30 +76,29 @@ Please use homebrew to install the missing command line tools.
 The `text-extraction.yml` should look like this:
     
 ```yml
-text_extractors:
-  pdftotext:
-   - /usr/local/bin/pdftotext
-   - -enc
-   - UTF-8
-   - __FILE__
-   - '-'
+pdftotext:
+  - /usr/local/bin/pdftotext
+  - -enc
+  - UTF-8
+  - __FILE__
+  - '-'
 
-  unrtf:
-    - /usr/local/bin/unrtf
-    - --text
-    - __FILE__
+unrtf:
+  - /usr/local/bin/unrtf
+  - --text
+  - __FILE__
 
-  tesseract:
-    - /usr/local/bin/tesseract
-    - __FILE__
-    - stdout
+tesseract:
+  - /usr/local/bin/tesseract
+  - __FILE__
+  - stdout
 
-  catdoc:
-    - /usr/bin/textutil
-    - -convert
-    - txt
-    - -stdout
-    - __FILE__
+catdoc:
+  - /usr/bin/textutil
+  - -convert
+  - txt
+  - -stdout
+  - __FILE__
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ Or install it yourself as:
 In a Rails application save `text-extractor.yml.example` in `config/text-extractor.yml` and overwrite the settings to 
 your needs.
 
+Then load that configuration file in an initializer. Add the following lines to `config/initializers/text_extractor.rb`:
+
+```ruby
+file_name = File.join([Rails.root.to_s, 'config', 'text_extractor.yml'])
+if File.file?(file_name)
+  config_file = File.read(file_name)
+  TextExtractor::Configuration.load(config_file)
+end
+````
+
 #### Plain Ruby
 
 Please overwrite `TextExtractor::Configuration.load`.

--- a/lib/text_extractor/configuration.rb
+++ b/lib/text_extractor/configuration.rb
@@ -2,27 +2,24 @@
 
 module TextExtractor
   module Configuration
-    @@config = nil
-
     class << self
+      attr_accessor :config
+
       # Returns a configuration setting
       def [](name)
-        load unless @@config
-        @@config[name]
+        load if self.config.nil?
+        self.config[name]
       end
 
-      def load
-        @@config = {}
-        if defined?(Rails)
-          filename = File.join([Rails.root.to_s, 'config', 'text_extractor.yml'])
-          if File.file?(filename)
-            file_config = YAML::load(ERB.new(File.read(filename)).result)
-            if file_config.is_a? Hash
-              @@config = file_config
-            else
-              warn "#{filename} is not a valid TextExtractor configuration file, ignoring."
-            end
-          end
+      def load(config_file = nil)
+        self.config = {}
+        return unless config_file
+
+        file_config = YAML::load(ERB.new(config_file).result)
+        if file_config.is_a?(Hash)
+          self.config = file_config
+        else
+          warn "`config_file` is not a valid TextExtractor configuration file, ignoring."
         end
       end
     end

--- a/lib/text_extractor/file_handler.rb
+++ b/lib/text_extractor/file_handler.rb
@@ -2,7 +2,6 @@
 
 module TextExtractor
   class FileHandler
-    TEXT_EXTRACTORS = TextExtractor::Configuration['text_extractors'] || {}
     def accept?(content_type)
       if @content_type
         content_type == @content_type

--- a/lib/text_extractor/file_handler/external_command_handler/doc_handler.rb
+++ b/lib/text_extractor/file_handler/external_command_handler/doc_handler.rb
@@ -11,7 +11,7 @@ module TextExtractor
     ]
     def initialize
       @content_types = CONTENT_TYPES
-      @command = TextExtractor::FileHandler::TEXT_EXTRACTORS['catdoc'] || DEFAULT
+      @command = TextExtractor::Configuration['catdoc'] || DEFAULT
     end
   end
 end

--- a/lib/text_extractor/file_handler/external_command_handler/image_handler.rb
+++ b/lib/text_extractor/file_handler/external_command_handler/image_handler.rb
@@ -12,7 +12,7 @@ module TextExtractor
     ].freeze
     def initialize
       @content_types = CONTENT_TYPES
-      @command = TextExtractor::FileHandler::TEXT_EXTRACTORS['tesseract'] || DEFAULT
+      @command = TextExtractor::Configuration['tesseract'] || DEFAULT
     end
   end
 end

--- a/lib/text_extractor/file_handler/external_command_handler/pdf_handler.rb
+++ b/lib/text_extractor/file_handler/external_command_handler/pdf_handler.rb
@@ -7,7 +7,7 @@ module TextExtractor
     ].freeze
     def initialize
       @content_type = 'application/pdf'
-      @command = TextExtractor::FileHandler::TEXT_EXTRACTORS['pdftotext'] || DEFAULT
+      @command = TextExtractor::Configuration['pdftotext'] || DEFAULT
     end
   end
 end

--- a/lib/text_extractor/file_handler/external_command_handler/ppt_handler.rb
+++ b/lib/text_extractor/file_handler/external_command_handler/ppt_handler.rb
@@ -11,7 +11,7 @@ module TextExtractor
     ]
     def initialize
       @content_types = CONTENT_TYPES
-      @command = TextExtractor::FileHandler::TEXT_EXTRACTORS['catppt'] || DEFAULT
+      @command = TextExtractor::Configuration['catppt'] || DEFAULT
     end
   end
 end

--- a/lib/text_extractor/file_handler/external_command_handler/rtf_handler.rb
+++ b/lib/text_extractor/file_handler/external_command_handler/rtf_handler.rb
@@ -7,7 +7,7 @@ module TextExtractor
     ].freeze
     def initialize
       @content_type = 'application/rtf'
-      @command = TextExtractor::FileHandler::TEXT_EXTRACTORS['unrtf'] || DEFAULT
+      @command = TextExtractor::Configuration['unrtf'] || DEFAULT
     end
   end
 end

--- a/lib/text_extractor/file_handler/external_command_handler/xls_handler.rb
+++ b/lib/text_extractor/file_handler/external_command_handler/xls_handler.rb
@@ -11,7 +11,7 @@ module TextExtractor
     ]
     def initialize
       @content_types = CONTENT_TYPES
-      @command = TextExtractor::FileHandler::TEXT_EXTRACTORS['xls2csv'] || DEFAULT
+      @command = TextExtractor::Configuration['xls2csv'] || DEFAULT
     end
     def text(*_)
       if str = super

--- a/text-extractor.yml.example
+++ b/text-extractor.yml.example
@@ -5,37 +5,37 @@
 #
 # commands should write the resulting plain text to STDOUT. Use __FILE__ as
 # placeholder for the file path. The values below are the defaults.
-text_extractors:
-  # apt-get install poppler-utils
-  # pdftotext:
-  #   - /usr/bin/pdftotext
-  #   - -enc
-  #   - UTF-8
-  #   - __FILE__
-  #   - '-'
 
-  # apt-get install unrtf
-  # unrtf:
-  #   - /usr/bin/unrtf
-  #   - --text
-  #   - __FILE__
+# apt-get install poppler-utils
+# pdftotext:
+#   - /usr/bin/pdftotext
+#   - -enc
+#   - UTF-8
+#   - __FILE__
+#   - '-'
 
-  # apt-get install catdoc
-  # catdoc:
-  #   - /usr/bin/catdoc
-  #   - -dutf-8
-  #   - __FILE__
-  # xls2csv:
-  #   - /usr/bin/xls2csv
-  #   - -dutf-8
-  #   - __FILE__
-  # catppt:
-  #   - /usr/bin/catppt
-  #   - -dutf-8
-  #   - __FILE__
+# apt-get install unrtf
+# unrtf:
+#   - /usr/bin/unrtf
+#   - --text
+#   - __FILE__
 
-  # apt-get install tesseract-ocr
-  # tesseract:
-  #   - /usr/bin/tesseract
-  #   - -dutf-8
-  #   - __FILE__
+# apt-get install catdoc
+# catdoc:
+#   - /usr/bin/catdoc
+#   - -dutf-8
+#   - __FILE__
+# xls2csv:
+#   - /usr/bin/xls2csv
+#   - -dutf-8
+#   - __FILE__
+# catppt:
+#   - /usr/bin/catppt
+#   - -dutf-8
+#   - __FILE__
+
+# apt-get install tesseract-ocr
+# tesseract:
+#   - /usr/bin/tesseract
+#   - -dutf-8
+#   - __FILE__


### PR DESCRIPTION
For using this gem inside a Rails application we need to be able to configure it after the code got initialised.

Explanation: Before this commit the gem got initialised before Rails was ready, thus we could not rely on `Rails.root` to be ready. So we could not get the correct path to the config file. I believe that this is due to the fact that the orignal code was not a gem but a patch to Redmine. So when it got loaded the configuration was there. However, we now have a different situation.